### PR TITLE
send APEL summary to the server

### DIFF
--- a/apel_plugin.cfg
+++ b/apel_plugin.cfg
@@ -9,7 +9,6 @@ report_interval = 20
 site_name_mapping = {"atlas-bfg": "UNI-FREIBURG"}
 submit_host = https://xxx.bfg.uni-freiburg.de:1234/xxx
 infrastructure_type = grid
-benchmark_type = HEPSPEC
 
 [auditor]
 auditor_ip = 127.0.0.1
@@ -25,6 +24,7 @@ vo_mapping = {
 
 [authentication]
 auth_url = https://192.168.56.2:8443/v1/service-types/ams/hosts/ams:authx509
+ams_url = https://192.168.56.2:443/v1/projects/accounting/topics/topic1:publish?key=
 client_cert = /home/dirk/test/client.pem
 client_key = /home/dirk/test/client.key
 ca_path = /etc/grid-security/certificates

--- a/apel_plugin.cfg
+++ b/apel_plugin.cfg
@@ -22,3 +22,9 @@ vo_mapping = {
 	   "^atl": {"vo": "atlas", "vogroup": "/atlas/Role", "vorole": "Role=NULL"},
 	   "^ops": {"vo": "ops", "vogroup": "/ops", "vorole": "Role=NULL"}
 	   }
+
+[authentication]
+auth_url = https://192.168.56.2:8443/v1/service-types/ams/hosts/ams:authx509
+client_cert = /home/dirk/test/client.pem
+client_key = /home/dirk/test/client.key
+ca_path = /etc/grid-security/certificates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,17 +11,18 @@ dependencies = [
 	     "pytz==2022.2.1",
 	     "aiosqlite==0.17.0",
 	     "requests==2.28.1",
+	     "cryptography==38.0.1",
 ]
 
 [project.optional-dependencies]
 style = [
        "black",
-       "flake8"
+       "flake8",
 ]
 tests = [
       "pytest",
       "pytest-asyncio",
-      "pytest-cov"
+      "pytest-cov",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
 	     "python-auditor==0.0.6",
 	     "pytz==2022.2.1",
 	     "aiosqlite==0.17.0",
+	     "requests==2.28.1",
 ]
 
 [project.optional-dependencies]

--- a/src/apel_plugin/apel_plugin.py
+++ b/src/apel_plugin/apel_plugin.py
@@ -353,6 +353,15 @@ async def sign_msg(config, msg):
     return signed_msg
 
 
+async def build_payload(msg):
+    current_time = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    empaid = f"{current_time[:8]}/{current_time}"
+
+    payload = {"attributes": {"empaid": empaid}, "data": msg}
+
+    return payload
+
+
 async def run(config, client):
     run_interval = config["intervals"].getint("run_interval")
     report_interval = config["intervals"].getint("report_interval")
@@ -390,6 +399,8 @@ async def run(config, client):
             logging.debug(signed_summary)
             encoded_summary = base64.b64encode(signed_summary).decode("utf-8")
             logging.debug(encoded_summary)
+            payload_summary = await build_payload(encoded_summary)
+            logging.debug(payload_summary)
 
             latest_report_time = datetime.now()
             await update_time_db(

--- a/src/apel_plugin/apel_plugin.py
+++ b/src/apel_plugin/apel_plugin.py
@@ -21,6 +21,7 @@ import requests
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.serialization import pkcs7
+import base64
 
 
 async def regex_dict_lookup(term, dict):
@@ -387,6 +388,8 @@ async def run(config, client):
             logging.debug(token)
             signed_summary = await sign_msg(config, summary)
             logging.debug(signed_summary)
+            encoded_summary = base64.b64encode(signed_summary).decode("utf-8")
+            logging.debug(encoded_summary)
 
             latest_report_time = datetime.now()
             await update_time_db(


### PR DESCRIPTION
This PR implements the functions to send the APEL summary to the server. For now, a test server in a local VM is used. CA verification for the server is currently set to `False`. Setting `ca_path` to `/etc/grid-security/certificates` in a production environment should be correct.

- [x] get a token from the server
  - [x] get token only once?
- [x] sign the data (i.e. the summary)
- [x] encode the data
- [x] build the payload
- [x] send the payload to the server

Since we're sending a NormalisedSummary, the ServiceLevel and ServiceLevelType fields are not needed (and result in an Error). Therefore, they are removed with this PR.
