### PR TITLE
obtain submithost from record

### DIFF
--- a/apel_plugin.cfg
+++ b/apel_plugin.cfg
@@ -8,10 +8,10 @@ time_db_path = time.db
 report_interval = 20
 
 [site]
-publish_since = 2022-12-20 14:27:39+00:00
+publish_since = 2023-03-13 00:00:00+00:00
 sites_to_report = ["atlas-bfg"]
 site_name_mapping = {"atlas-bfg": "UNI-FREIBURG"}
-submit_host = https://xxx.bfg.uni-freiburg.de:1234/xxx
+default_submit_host = gsiftp://arc.bfg.uni-freiburg.de:2811/jobs
 infrastructure_type = grid
 
 [auditor]
@@ -23,6 +23,7 @@ cpu_time_name = TotalCPU
 nnodes_name = NNodes
 meta_key_site = site_id
 meta_key_user = user_id
+meta_key_submithost = headnode
 
 [uservo]
 vo_mapping = {


### PR DESCRIPTION
With this PR, the submithost is obtained from the record if possible, otherwise a default from the config file is used.
Coverage decreases because `create_sync_db` is not tested yet.