### PR TITLE
limit style check workflow to python 3.11

### DIFF
--- a/.github/workflows/style_checks.yml
+++ b/.github/workflows/style_checks.yml
@@ -8,16 +8,13 @@ on:
 jobs:
   check-style:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.11
       - name: Install dependencies
         run: |
           pip install --upgrade pip


### PR DESCRIPTION
This PR limit the github workflow for the style checks to Python 3.11.