### PR TITLE
switch to hepscore23 and add benchmark information to APEL summary

### DIFF
--- a/auditor_apel_plugin.cfg
+++ b/auditor_apel_plugin.cfg
@@ -13,12 +13,13 @@ sites_to_report = ["atlas-bfg"]
 site_name_mapping = {"atlas-bfg": "UNI-FREIBURG"}
 default_submit_host = gsiftp://arc.bfg.uni-freiburg.de:2811/jobs
 infrastructure_type = grid
+benchmark_type = hepscore23
 
 [auditor]
 auditor_ip = 127.0.0.1
 auditor_port = 3333
 auditor_timeout = 60
-benchmark_name = HEPSPEC06
+benchmark_name = hepscore23
 cores_name = Cores
 cpu_time_name = TotalCPU
 nnodes_name = NNodes

--- a/tests/test_auditor_apel_plugin.py
+++ b/tests/test_auditor_apel_plugin.py
@@ -345,7 +345,7 @@ class TestAuditorApelPlugin:
         sites_to_report = '["test-site-1", "test-site-2"]'
         default_submit_host = "https://default.submit_host.de:1234/xxx"
         infrastructure_type = "grid"
-        benchmark_name = "HEPSPEC06"
+        benchmark_name = "hepscore"
         cores_name = "Cores"
         cpu_time_name = "TotalCPU"
         nnodes_name = "NNodes"
@@ -353,6 +353,7 @@ class TestAuditorApelPlugin:
         meta_key_submithost = "headnode"
         meta_key_voms = "voms"
         meta_key_username = "subject"
+        benchmark_type = "hepscore23"
 
         conf = configparser.ConfigParser()
         conf["site"] = {
@@ -360,6 +361,7 @@ class TestAuditorApelPlugin:
             "sites_to_report": sites_to_report,
             "default_submit_host": default_submit_host,
             "infrastructure_type": infrastructure_type,
+            "benchmark_type": benchmark_type,
         }
         conf["auditor"] = {
             "benchmark_name": benchmark_name,
@@ -469,6 +471,7 @@ class TestAuditorApelPlugin:
             "sites_to_report": sites_to_report,
             "default_submit_host": default_submit_host,
             "infrastructure_type": infrastructure_type,
+            "benchmark_type": benchmark_type,
         }
 
         records = []
@@ -550,7 +553,7 @@ class TestAuditorApelPlugin:
         sites_to_report = '["test-site-1", "test-site-2"]'
         default_submit_host = "https://default.submit_host.de:1234/xxx"
         infrastructure_type = "grid"
-        benchmark_name = "HEPSPEC06"
+        benchmark_name = "hepscore"
         cores_name = "Cores"
         cpu_time_name = "TotalCPU"
         nnodes_name = "NNodes"
@@ -558,6 +561,7 @@ class TestAuditorApelPlugin:
         meta_key_submithost = "headnode"
         meta_key_voms = "voms"
         meta_key_username = "subject"
+        benchmark_type = "hepscore23"
 
         conf = configparser.ConfigParser()
         conf["site"] = {
@@ -565,6 +569,7 @@ class TestAuditorApelPlugin:
             "sites_to_report": sites_to_report,
             "default_submit_host": default_submit_host,
             "infrastructure_type": infrastructure_type,
+            "benchmark_type": benchmark_type,
         }
         conf["auditor"] = {
             "benchmark_name": benchmark_name,
@@ -642,7 +647,7 @@ class TestAuditorApelPlugin:
                 create_summary_db(conf, records)
             assert pytest_error.type == KeyError
 
-            conf["auditor"]["benchmark_name"] = "HEPSPEC06"
+            conf["auditor"]["benchmark_name"] = "hepscore"
             conf["site"][
                 "site_name_mapping"
             ] = '{"test-site-2": "TEST_SITE_2"}'
@@ -657,7 +662,7 @@ class TestAuditorApelPlugin:
 
     def test_get_submit_host(self):
         default_submit_host = "https://default.submit_host.de:1234/xxx"
-        benchmark_name = "HEPSPEC06"
+        benchmark_name = "hepscore"
         cores_name = "Cores"
         cpu_time_name = "TotalCPU"
         nnodes_name = "NNodes"
@@ -749,7 +754,7 @@ class TestAuditorApelPlugin:
 
     def test_get_voms_info(self):
         default_submit_host = "https://default.submit_host.de:1234/xxx"
-        benchmark_name = "HEPSPEC06"
+        benchmark_name = "hepscore"
         cores_name = "Cores"
         cpu_time_name = "TotalCPU"
         nnodes_name = "NNodes"
@@ -927,7 +932,7 @@ class TestAuditorApelPlugin:
         sites_to_report = '["test-site-1", "test-site-2"]'
         default_submit_host = "https://default.submit_host.de:1234/xxx"
         infrastructure_type = "grid"
-        benchmark_name = "HEPSPEC06"
+        benchmark_name = "hepscore"
         cores_name = "Cores"
         cpu_time_name = "TotalCPU"
         nnodes_name = "NNodes"
@@ -998,7 +1003,7 @@ class TestAuditorApelPlugin:
         sites_to_report = '["test-site-1", "test-site-2"]'
         default_submit_host = "https://default.submit_host.de:1234/xxx"
         infrastructure_type = "grid"
-        benchmark_name = "HEPSPEC06"
+        benchmark_name = "hepscore"
         cores_name = "Cores"
         cpu_time_name = "TotalCPU"
         nnodes_name = "NNodes"


### PR DESCRIPTION
This PR switches from HEPSPEC06 to hepscore23 (in the config file) and adds information about the benchmark to the APEL summary.
Decrease in coverage is in a part of the code that is not tested yet, please ignore :frowning_face: 