### PR TITLE
change workflows for publishing

### DIFF
--- a/.github/workflows/publish_pypi_git.yml
+++ b/.github/workflows/publish_pypi_git.yml
@@ -1,0 +1,30 @@
+name: publish-pypi-git
+
+on:
+  push:
+    tags:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install build
+        run: |
+          pip install --upgrade pip
+          pip install .[build]
+      - name: Build binary wheel and source tarball
+        run: python3 -m build --sdist --wheel --outdir dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*

--- a/.github/workflows/publish_pypi_test.yml
+++ b/.github/workflows/publish_pypi_test.yml
@@ -1,9 +1,8 @@
-name: pypi-publish
+name: publish-pypi-test
 
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 jobs:
   build-and-publish:
@@ -29,11 +28,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-      - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
-      - name: Publish to GitHub
-        if: startsWith(github.ref, 'refs/tags')
-        uses: softprops/action-gh-release@v1
-        with:
-          files: dist/*


### PR DESCRIPTION
This PR should finally introduce the correct workflows for publishing to GitHub and PyPI:

- push commit to main: publish to the PyPI Test Server
- push tag: publish to PyPI Server and GitHub