### PR TITLE
another fix for the publish workflows

### DIFF
--- a/.github/workflows/publish_pypi_git.yml
+++ b/.github/workflows/publish_pypi_git.yml
@@ -3,6 +3,7 @@ name: publish-pypi-git
 on:
   push:
     tags:
+      - v*
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
Run workflow only if tag starts with v