### PR TITLE
add option to verify server certificate

### DIFF
--- a/auditor_apel_plugin.cfg
+++ b/auditor_apel_plugin.cfg
@@ -34,3 +34,4 @@ ams_url = https://192.168.56.2:443/v1/projects/accounting/topics/topic1:publish?
 client_cert = /home/dirk/test/client.pem
 client_key = /home/dirk/test/client.key
 ca_path = /etc/grid-security/certificates
+verify_ca = True

--- a/src/auditor_apel_plugin/core.py
+++ b/src/auditor_apel_plugin/core.py
@@ -630,10 +630,14 @@ def get_token(config):
     auth_url = config["authentication"].get("auth_url")
     client_cert = config["authentication"].get("client_cert")
     client_key = config["authentication"].get("client_key")
-    # ca_path = config["authentication"].get("ca_path")
+    verify_ca = config["authentication"].getboolean("verify_ca")
+    if verify_ca:
+        ca_path = config["authentication"].get("ca_path")
+    else:
+        ca_path = False
 
     response = requests.get(
-        auth_url, cert=(client_cert, client_key), verify=False
+        auth_url, cert=(client_cert, client_key), verify=ca_path
     )
     token = response.json()["token"]
 
@@ -669,14 +673,19 @@ def build_payload(msg):
 
 
 def send_payload(config, token, payload):
-    # ca_path = config["authentication"].get("ca_path")
     ams_url = config["authentication"].get("ams_url")
+    verify_ca = config["authentication"].getboolean("verify_ca")
+    if verify_ca:
+        ca_path = config["authentication"].get("ca_path")
+    else:
+        ca_path = False
+
     logging.debug(f"{ams_url}{token}")
     post = requests.post(
         f"{ams_url}{token}",
         json=payload,
         headers={"Content-Type": "application/json"},
-        verify=False,
+        verify=ca_path,
     )
 
     return post


### PR DESCRIPTION
This PR adds the option to verify the server certificate. Default in the config is `True`, setting it to `False` might be necessary for local test setups.