### PR TITLE
remove default behavior for site_name without site_name_mapping

### DIFF
--- a/src/auditor_apel_plugin/core.py
+++ b/src/auditor_apel_plugin/core.py
@@ -295,11 +295,7 @@ def create_summary_db(config, records):
         logging.critical(e)
         raise e
 
-    try:
-        site_name_mapping = json.loads(config["site"].get("site_name_mapping"))
-    except TypeError:
-        site_name_mapping = None
-
+    site_name_mapping = json.loads(config["site"].get("site_name_mapping"))
     sites_to_report = json.loads(config["site"].get("sites_to_report"))
     infrastructure = config["site"].get("infrastructure_type")
     benchmark_type = config["site"].get("benchmark_type")
@@ -315,16 +311,13 @@ def create_summary_db(config, records):
         if site_id not in sites_to_report:
             continue
 
-        if site_name_mapping is not None:
-            try:
-                site_name = site_name_mapping[site_id]
-            except KeyError:
-                logging.critical(
-                    f"No site name mapping defined for site {site_id}"
-                )
-                raise KeyError
-        else:
-            site_name = site_id
+        try:
+            site_name = site_name_mapping[site_id]
+        except KeyError:
+            logging.critical(
+                f"No site name mapping defined for site {site_id}"
+            )
+            raise
 
         submit_host = get_submit_host(r, config)
 
@@ -447,11 +440,7 @@ def create_sync_db(config, records):
         logging.critical(e)
         raise e
 
-    try:
-        site_name_mapping = json.loads(config["site"].get("site_name_mapping"))
-    except TypeError:
-        site_name_mapping = None
-
+    site_name_mapping = json.loads(config["site"].get("site_name_mapping"))
     sites_to_report = json.loads(config["site"].get("sites_to_report"))
 
     for r in records:
@@ -459,16 +448,14 @@ def create_sync_db(config, records):
 
         if site_id not in sites_to_report:
             continue
-        if site_name_mapping is not None:
-            try:
-                site_name = site_name_mapping[site_id]
-            except KeyError:
-                logging.critical(
-                    f"No site name mapping defined for site {site_id}"
-                )
-                sys.exit(1)
-        else:
-            site_name = site_id
+
+        try:
+            site_name = site_name_mapping[site_id]
+        except KeyError:
+            logging.critical(
+                f"No site name mapping defined for site {site_id}"
+            )
+            raise
 
         submit_host = get_submit_host(r, config)
 

--- a/tests/test_auditor_apel_plugin.py
+++ b/tests/test_auditor_apel_plugin.py
@@ -467,37 +467,6 @@ class TestAuditorApelPlugin:
                 rec_values["user_name"]
             )
 
-        conf["site"] = {
-            "sites_to_report": sites_to_report,
-            "default_submit_host": default_submit_host,
-            "infrastructure_type": infrastructure_type,
-            "benchmark_type": benchmark_type,
-        }
-
-        records = []
-
-        with patch(
-            "pyauditor.Record.runtime", new_callable=PropertyMock
-        ) as mocked_runtime:
-            mocked_runtime.return_value = runtime
-
-            for r_values in rec_value_list:
-                rec = create_rec(r_values, conf["auditor"])
-                records.append(rec)
-
-            result = create_summary_db(conf, records)
-
-        cur = result.cursor()
-
-        cur.execute("SELECT * FROM records")
-        content = cur.fetchall()
-
-        for idx, rec_values in enumerate(rec_value_list):
-            assert content[idx][0] == rec_values["site"]
-
-        cur.close()
-        result.close()
-
         rec_1_values["user_name"] = None
         records = []
 


### PR DESCRIPTION
This PR removes the default behavior for `site_name`, i.e. just take `site_id` from the record, when `site_name_mapping` is not present in the config. Therefore, `site_name_mapping` must be defined in the config.